### PR TITLE
fix grid error

### DIFF
--- a/components/nacelle/ProductCard.vue
+++ b/components/nacelle/ProductCard.vue
@@ -127,8 +127,9 @@ export default {
     },
     options() {
       return (
-        this.$store.state[`product/${this.product.handle}`] || this.product
-      ).options || []
+        (this.$store.state[`product/${this.product.handle}`] || this.product)
+          .options || []
+      )
     },
     displayPrice() {
       if (this.selectedVariant) {

--- a/components/nacelle/ProductRecommendations.vue
+++ b/components/nacelle/ProductRecommendations.vue
@@ -15,9 +15,7 @@
             :key="recommendedProduct.handle"
             :class="columnClasses"
           >
-            <product-card
-              :product="recommendedProduct"
-            />
+            <product-card :product="recommendedProduct" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### WHY are these changes introduced?

For [[ENG-2087](https://nacelle.atlassian.net/browse/ENG-2087)]

The product grid for recommendations was not loading properly. Also, some products would fail to build.

### WHAT is this pull request doing?

- Removes namespace check on product-cards in `ProductRecommendations.vue`
- defaults the `options` field to an empty array if it does not exist.