### PR TITLE
Fix small desktop [ProductGrid] overlap

### DIFF
--- a/components/nacelle/ProductCard.vue
+++ b/components/nacelle/ProductCard.vue
@@ -181,7 +181,10 @@ export default {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-width: 300px;
+  flex-wrap: wrap;
+  div {
+    margin: 5px 0;
+  }
 }
 
 .product-card-details ::v-deep a {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13000,6 +13000,7 @@
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
       "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },


### PR DESCRIPTION
**Ticket**

https://nacelle.atlassian.net/browse/DD-843

**Changes**

Made sure the flexbox in product cards wraps instead of bleeding over neighboring product cards

![image](https://user-images.githubusercontent.com/25146108/130847758-25d11c85-41da-4907-ac13-769dce39186d.png)

**Testing**

Go to `/clothing` and see if viewport width causes product cards to bleed over each other
