### PR TITLE
Fix activeRange prop default value

### DIFF
--- a/providers/RefinementProvider.js
+++ b/providers/RefinementProvider.js
@@ -34,7 +34,7 @@ export default {
      */
     activePriceRange: {
       type: Object,
-      default: () => {}
+      default: () => ({})
     },
     sortBy: {
       type: String,


### PR DESCRIPTION
Just a quick fix for `activeRange` prop default value in `RefinementProvider`